### PR TITLE
Potential fix for code scanning alert no. 4: Use of potentially dangerous function

### DIFF
--- a/src/password_saving.c
+++ b/src/password_saving.c
@@ -26,10 +26,11 @@ char remarks[200] = "";
 // Function to get current date and time
 void getCurrentDateTime(char *dateStr, char *timeStr) {
     time_t now = time(NULL);
-    struct tm *t = localtime(&now);
+    struct tm t;
+    localtime_r(&now, &t);
 
-    strftime(dateStr, 11, "%d/%m/%Y", t);
-    strftime(timeStr, 6, "%H:%M", t);
+    strftime(dateStr, 11, "%d/%m/%Y", &t);
+    strftime(timeStr, 6, "%H:%M", &t);
 }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Cherry-Corp/Test/security/code-scanning/4](https://github.com/Cherry-Corp/Test/security/code-scanning/4)

To fix this issue, modify the call to `localtime` in `getCurrentDateTime` to use the thread-safe reentrant version, `localtime_r`. This requires allocating a local (stack) `struct tm` variable and passing its pointer to `localtime_r`, which fills in the time structure. Adjust all usages in the function to point to the local variable instead of the pointer returned by `localtime`. The changes are confined to the `getCurrentDateTime` function in `src/password_saving.c`, specifically lines 27-33.

No extra includes or library installations are needed, as `localtime_r` is a well-known POSIX function available on all modern platforms.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
