### PR TITLE
Potential fix for code scanning alert no. 3: File created without restricting permissions

### DIFF
--- a/src/password_saving.c
+++ b/src/password_saving.c
@@ -12,6 +12,8 @@
  * */
 
 #include "../include/password_generator.h"
+#include <fcntl.h>     // for open()
+#include <sys/stat.h>  // for S_IRUSR, S_IWUSR
 
 // Data Array
 char date[11];             // "dd/mm/yyyy" + null terminator
@@ -53,7 +55,8 @@ void savePassword(bool choice, const char *generatedPassword) {
     ofn.lpstrDefExt = "csv";
 
     if (GetSaveFileName(&ofn)) {
-        FILE *fp = fopen(fileName, "w");
+        int fd = open(fileName, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR); // 0600
+        FILE *fp = (fd != -1) ? fdopen(fd, "w") : NULL;
         if (fp != NULL) {
             // Get current date and time
             getCurrentDateTime(date, timeStr);


### PR DESCRIPTION
Potential fix for [https://github.com/Cherry-Corp/Test/security/code-scanning/3](https://github.com/Cherry-Corp/Test/security/code-scanning/3)

To fix the issue, ensure the file is created with the most restrictive permissions possible (ideally read and write for the current user only), regardless of the user's umask. 

The standard way to do this in C is:
- Open (or create) the file using `open()` with the `O_CREAT` flag and explicitly set permissions (`S_IRUSR | S_IWUSR`).
- Then, use `fdopen()` to obtain a `FILE*` stream if you require standard I/O operations.

This fix should be applied within the block that opens the file (line 56). You may need to add `#include <fcntl.h>` and `#include <sys/stat.h>` for the mode and open flags.  
Restrict edits to just the relevant snippet: remove or comment out `fopen`, and instead use `open`, `fdopen`, and finally close with `fclose()` which closes the underlying descriptor.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
